### PR TITLE
Adjust schema and resolvers for articles

### DIFF
--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -13,7 +13,7 @@ type Article {
   id: ID!
   title: String!
   summary: String
-  content: String!
+  content: String
   headerImageURL: String
   author: User!
   categories: [Category]
@@ -58,14 +58,14 @@ type Comment {
 
 input CreateOrUpdateArticleInput {
   id:  ID
-  title: String!
+  title: String
   summary: String
-  content: String!
+  content: String
   headerImageURL: String
   createdAt: String
   updatedAt: String
   userId: String
-  subscribersOnly: Boolean!
+  subscribersOnly: Boolean
   draft: Boolean
 }
 


### PR DESCRIPTION
This PR:
- [x] Makes more of the Article schema optional (for draft purposes)
- [x] Adds proper queries to the `articlesByUser` query
- [x] Adds the `userId` to an article upon creation
- [x] Fixes article ID bug