### PR TITLE
Add the optional ability to get drafts for self

### DIFF
--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -2,7 +2,7 @@ type Query {
   articles: [Article]
   article(id: ID!): Article
   articleBySlug(slug: String!): Article
-  articlesByUser(userId: ID!): [Article]
+  articlesByUser(userId: ID!, drafts: Boolean): [Article]
   me(userId: ID!): User!
   user(username: String!): User
 }


### PR DESCRIPTION
This PR:
- [x] Adds a flag to the `articlesByUser` query so that a user can get their own drafts

_Note: Before they were always included but we don't want that. If they view their own profile, the drafts shouldn't show. Should move drafts into their own query?_