### PR TITLE
Enable deletion of articles

### DIFF
--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -11,6 +11,7 @@ type Query {
 type Mutation {
   createOrUpdateArticle(input: CreateOrUpdateArticleInput!): CreateOrUpdateArticlePayload!
   publishArticle(input: PublishArticleInput!): PublishArticlePayload!
+  deleteArticle(input: DeleteArticleInput!): DeleteArticlePayload!
   createUser(input: CreateUserInput!): CreateUserPayload!
 }
 
@@ -25,10 +26,10 @@ type Article {
   comments: [Comment]
   likes: Int!
   wordLength: Int!
-  draft: Boolean!
   createdAt: String!
   updatedAt: String!
   publishedAt: String
+  deletedAt: String
   userId: String!
   subscribersOnly: Boolean!
   slug: String
@@ -87,7 +88,6 @@ input CreateOrUpdateArticleInput {
   updatedAt: String
   userId: String
   subscribersOnly: Boolean
-  draft: Boolean
 }
 
 type CreateOrUpdateArticlePayload {
@@ -102,6 +102,14 @@ input PublishArticleInput {
 type PublishArticlePayload {
   id: ID!
   slug: String!
+}
+
+input DeleteArticleInput {
+  id: ID!
+}
+
+type DeleteArticlePayload {
+  id: ID!
 }
 
 input CreateUserInput {


### PR DESCRIPTION
This PR:
- [x] Adds `deleteArticle` mutation
- [x] Removes `draft` from an `Article`
- [x] Updates all firestore queries to have appropriate usage of `publishedAt`
- [x] Adds `deletedAt` on an `Article` and updates queries to make use of it
- [x] Adds default values for an `Article` upon creation