### PR TITLE
Add the ability to view and cancel subscriptions

### DIFF
--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -3,12 +3,14 @@ import merge from 'lodash.merge';
 
 import articles from './articles';
 import stripe from './stripe';
+import subscriptions from './subscriptions';
 import users from './users';
 import unsplashPhotos from './unsplashPhotos';
 
 const resolvers: IResolvers = merge(
   articles,
   stripe,
+  subscriptions,
   users,
   unsplashPhotos,
 ) as ResolversObject<any>;

--- a/src/resolvers/subscriptions.ts
+++ b/src/resolvers/subscriptions.ts
@@ -1,0 +1,168 @@
+import { AuthenticationError, ApolloError, UserInputError } from 'apollo-server';
+import Stripe from 'stripe';
+
+import { getUserByStripeId, getUserById } from './users';
+
+import { Context } from '../types';
+import {
+  Subscription,
+  User,
+  CreateSubscriptionInput,
+  CreateSubscriptionPayload,
+  CancelSubscriptionInput,
+  CancelSubscriptionPayload,
+} from '../generated/graphql';
+
+export const getSubscriptionWithStripeData = async (
+  subscription: Subscription,
+  context: Context,
+): Promise<Subscription> => {
+  const author = await getUserById(subscription.authorId, context) as User;
+  if (!author) {
+    console.error('Failed to get Stripe subscription, user not found with ID:', subscription.authorId);
+    throw new ApolloError('User not found');
+  }
+  if (!author.stripeUserId) {
+    console.error('Failed to get Stripe subscription, user has no Stripe ID:', subscription.authorId);
+    throw new ApolloError('Invalid user');
+  }
+
+  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
+    apiVersion: '2020-03-02',
+    typescript: true,
+  });
+
+  try {
+    const stripeSubscription = await stripe.subscriptions.retrieve(subscription.stripeSubscriptionId, {
+      stripeAccount: author.stripeUserId,
+    });
+
+    return {
+      ...subscription,
+      status: stripeSubscription.status,
+      currentPeriodEnd: stripeSubscription.current_period_end,
+      cancelAt: stripeSubscription.cancel_at,
+      plan: stripeSubscription.plan,
+    } as Subscription;
+  } catch (error) {
+    console.error('Failed to get subscription:', error.message);
+  }
+
+  return subscription;
+}
+
+const subscription = async (
+  _: null,
+  args: { id: string },
+  context: Context,
+): Promise<Subscription | null> => {
+  const subscriptionDoc = await context.db.doc(`subscriptions/${args.id}`).get();
+  const subscription = subscriptionDoc.data() as Subscription | undefined;
+
+  return subscription ? {
+    id: subscriptionDoc.id,
+    ...subscription,
+  } : null;
+}
+
+export const createSubscription = async (
+  _: null,
+  { input }: { input: CreateSubscriptionInput },
+  context: Context,
+): Promise<CreateSubscriptionPayload> => {
+  if (!context.userId) {
+    throw new AuthenticationError('Not authenticated');
+  }
+
+  const author = await getUserByStripeId(input.stripeUserId, context);
+  if (!author) {
+    console.error('Failed to create a Stripe subscription, user not found with Stripe ID:', input.stripeUserId);
+    throw new ApolloError('Could not find Stripe account for user');
+  }
+
+  const subscriptionRef = await context.db.collection('subscriptions').add({
+    ...input,
+    userId: context.userId,
+    authorId: author.id,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    deletedAt: null,
+  });
+  const subscriptionDoc = await context.db.doc(`subscriptions/${subscriptionRef.id}`).get();
+
+  return { id: subscriptionDoc.id, ...subscriptionDoc.data() } as CreateSubscriptionPayload;
+}
+
+const cancelSubscription = async (
+  _: null,
+  { input }: { input: CancelSubscriptionInput },
+  context: Context,
+): Promise<CancelSubscriptionPayload> => {
+  if (!context.userId) {
+    throw new AuthenticationError('Not authenticated');
+  }
+
+  const subscriptionDoc = await context.db.doc(`subscriptions/${input.id}`).get();
+  const subscription = { id: subscriptionDoc.id, ...subscriptionDoc.data() } as Subscription;
+  const author = await getUserById(subscription.authorId, context);
+
+  if (!subscription) {
+    throw new UserInputError('Subscription not found');
+  }
+
+  if (context?.userId !== subscription.userId) {
+    throw new AuthenticationError('Not authorized');
+  }
+
+  if (!author?.stripeUserId) {
+    console.error('Failed to cancel subscription, subscription author does not have an associated Stripe account:', subscription);
+    throw new ApolloError('Author does not have an associated Stripe account');
+  }
+
+  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
+    apiVersion: '2020-03-02',
+    typescript: true,
+  });
+
+  try {
+    await stripe.subscriptions.del(subscription.stripeSubscriptionId, {
+      stripeAccount: author?.stripeUserId,
+    });
+  } catch (error) {
+    console.error('Failed to delete Stripe subscription:', error.message);
+    throw new ApolloError('Failed to cancel subscription');
+  }
+
+  const deleted = {
+    ...subscription,
+    deletedAt: new Date().toISOString()
+  };
+
+  await context.db
+    .doc(`subscriptions/${subscription.id}`)
+    .set(deleted, { merge: true });
+
+  return deleted as CancelSubscriptionPayload;
+}
+
+const author = async (
+  parent: Subscription,
+  _: null,
+  context: Context,
+): Promise<User | null> => {
+  const user = await getUserById(parent.authorId, context);
+  return user;
+}
+
+export default {
+  Query: {
+    subscription,
+  },
+  Mutation: {
+    createSubscription,
+    cancelSubscription,
+  },
+  Subscription: {
+    author,
+  }
+}

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -3,8 +3,8 @@ type Query {
   article(id: ID!): Article
   articleBySlug(slug: String!): Article
   articlesByUser(userId: ID!, drafts: Boolean): [Article]
-  me: User!
   stripeSession(id: ID!, stripeUserId: ID!): StripeSession!
+  subscription(id: ID!): Subscription!
   user(username: String!): User
   unsplashPhoto(search: String): [UnsplashPhoto]
 }
@@ -16,6 +16,8 @@ type Mutation {
   createUser(input: CreateUserInput!): CreateUserPayload!
   connectStripeAccount(input: ConnectStripeAccountInput!): ConnectStripeAccountPayload!
   createStripeSession(input: CreateStripeSessionInput): CreateStripeSessionPayload!
+  createSubscription(input: CreateSubscriptionInput): CreateSubscriptionPayload!
+  cancelSubscription(input: CancelSubscriptionInput): CancelSubscriptionPayload!
 }
 
 type ArticleHeaderImage {
@@ -56,6 +58,7 @@ type User {
   following: [String]
   followers: [String]
   subscribers: [String]
+  subscriptions: [Subscription]
   createdAt: String!
   updatedAt: String!
   stripeUserId: String
@@ -97,11 +100,34 @@ type UnsplashPhotoURLs {
 type StripeSession {
   id: ID!
   status: String
+  subscription: String
 }
 
 type StripePlan {
   id: ID!
   amount: Int
+  currency: String!
+  interval: String!
+}
+
+type Subscription {
+  id: ID!
+  stripeSubscriptionId: String!
+  authorId: String!
+  author: User!
+  userId: String!
+  status: String!
+  currentPeriodEnd: Int!
+  cancelAt: Int
+  createdAt: String!
+  updatedAt: String!
+  deletedAt: String
+  plan: Plan!
+}
+
+type Plan {
+  id: ID!
+  amount: Int!
   currency: String!
   interval: String!
 }
@@ -184,5 +210,25 @@ input CreateStripeSessionInput {
 }
 
 type CreateStripeSessionPayload {
+  id: ID!
+}
+
+input CreateSubscriptionInput {
+  stripeUserId: String!
+  stripeSubscriptionId: String!
+  authorId: String!
+}
+
+type CreateSubscriptionPayload {
+  id: ID!
+  stripeSubscriptionId: String!
+  createdAt: String!
+}
+
+input CancelSubscriptionInput {
+  id: ID!
+}
+
+type CancelSubscriptionPayload {
   id: ID!
 }


### PR DESCRIPTION
This PR:
- [x] Adds `subscriptions` resolver (create, cancel, view subscriptions)
- [x] Adds the ability to resolve subscriptions for a user
- [x] Fixes but that was supposed to check if a user had connected Stripe to their account
- [x] Removed redundant `me` resolver