### PR TITLE
Check to see if subscription was already saved

### DIFF
--- a/src/resolvers/subscriptions.ts
+++ b/src/resolvers/subscriptions.ts
@@ -80,6 +80,19 @@ export const createSubscription = async (
     throw new ApolloError('Could not find Stripe account for user');
   }
 
+  const subscriptions = await context.db.collection('subscriptions')
+    .where('userId', '==', context.userId)
+    .where('authorId', '==', author.id)
+    .where('deleteAt', '==', null)
+    .get();
+  const existingSubscriptions = subscriptions.docs
+    .map(subscription => ({ id: subscription.id, ...subscription.data() }));
+
+  // Return early if a sub already exists for the user/author and is active
+  if (existingSubscriptions.length) {
+    return existingSubscriptions[0] as CreateSubscriptionPayload;
+  }
+
   const subscriptionRef = await context.db.collection('subscriptions').add({
     ...input,
     userId: context.userId,


### PR DESCRIPTION
This PR checks to see if a subscription was already made before trying to create it.

_Note: The logic for creating a sub after checkout should probably be moved out of the query..._