### PR TITLE
Adjust for categories

### DIFF
--- a/src/resolvers/articles.ts
+++ b/src/resolvers/articles.ts
@@ -54,16 +54,30 @@ const getArticleContent = (article: Article, contentBlocked: boolean): string =>
 
 const articles = async (
   _: null, 
-  args: null,
+  args: { category: string },
   context: Context
 ): Promise<Article[]> => {
-  const articles = await context.db
-    .collection('articles')
-    .where('publishedAt', '>', '')
-    .where('deletedAt', '==', null)
-    .orderBy('publishedAt', 'desc')
-    .orderBy('updatedAt', 'desc')
-    .get();
+  let articles;
+  const category = args.category.toLowerCase();
+
+  if (category === 'all') {
+    articles = await context.db
+      .collection('articles')
+      .where('publishedAt', '>', '')
+      .where('deletedAt', '==', null)
+      .orderBy('publishedAt', 'desc')
+      .orderBy('updatedAt', 'desc')
+      .get();
+  } else {
+    articles = await context.db
+      .collection('articles')
+      .where('category', '==', category)
+      .where('publishedAt', '>', '')
+      .where('deletedAt', '==', null)
+      .orderBy('publishedAt', 'desc')
+      .orderBy('updatedAt', 'desc')
+      .get();
+  }
 
   return articles.docs.map(article => ({ id: article.id, ...article.data() })) as Article[];
 };
@@ -174,6 +188,7 @@ const createOrUpdateArticle = async (
     deletedAt: null,
     subscribersOnly: false,
     wordCount: 0,
+    category: null,
   };
 
   const article: CreateOrUpdateArticleInput = {

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -1,5 +1,5 @@
 type Query {
-  articles: [Article]
+  articles(category: String): [Article]
   article(id: ID!): Article
   articleBySlug(slug: String!): Article
   articlesByUser(userId: ID!, drafts: Boolean): [Article]
@@ -40,7 +40,7 @@ type Article {
   content: String
   headerImage: ArticleHeaderImage
   author: User!
-  categories: [Category]
+  category: Category
   comments: [Comment]
   likes: Int!
   wordCount: Int!
@@ -72,13 +72,6 @@ type User {
   stripeUserId: String
   stripePlanId: String
   stripePlan: StripePlan
-}
-
-type Category {
-  id: ID!
-  name: String!
-  createdAt: String!
-  updatedAt: String!
 }
 
 type Comment {
@@ -145,6 +138,22 @@ type Plan {
   interval: String!
 }
 
+enum Category {
+  arts
+  books
+  business
+  design
+  food
+  health
+  opinion
+  politics
+  science
+  sports
+  technology
+  travel
+  world
+}
+
 input ArticleHeaderImageInput {
   id: ID!
   url: String!
@@ -163,6 +172,7 @@ input CreateOrUpdateArticleInput {
   userId: String
   subscribersOnly: Boolean
   wordCount: Int
+  category: String
 }
 
 type CreateOrUpdateArticlePayload {


### PR DESCRIPTION
This PR:
- [x] Adds a `Category` enum
- [x] Adds the ability to get articles by category
- [x] Cleans up old `Category` types
- [x] Only allows one category per article