### PR TITLE
Add profile feed query

### DIFF
--- a/src/resolvers/feeds.ts
+++ b/src/resolvers/feeds.ts
@@ -1,7 +1,7 @@
 import { AuthenticationError } from 'apollo-server';
 
 import { Context } from '../types';
-import { Feed } from './../generated/graphql';
+import { Feed, ProfileFeed } from './../generated/graphql';
 
 import { getUserById } from './users';
 import { comment } from './comments';
@@ -16,14 +16,15 @@ const feed = async (
     throw new AuthenticationError('Not authenticated');
   }
 
-  const userTimeline = context.stream.feed('timeline', context.userId);
-  const feed = await userTimeline.get({ limit: 20 }) as any;
+  const timeline = context.stream.feed('timeline', context.userId);
+  const feed = await timeline.get({ limit: 20 }) as any;
 
   // Loop through activities and resolve them
   // Gross algorithm but we limit it
   // to 20 results at a time
   for (let i = 0; i < feed.results.length; i++) {
     const result = feed.results[i];
+
     for (let j = 0; j < result.activities.length; j++) {
       const activity = result.activities[j];
       const userIsActor = activity.actor === context.userId;
@@ -33,25 +34,33 @@ const feed = async (
       if (userIsActor) {
         // eslint-disable-next-line @typescript-eslint/camelcase
         result.actor_count -= 1;
-        result.activities[j] = null;
+
+        // If the user was the only actor
+        // we need to remove the result
+        if (result.actor_count === 0) {
+          feed.results[i] = null;
+        } else {
+          result.activities[j] = null;
+        }
+
         continue;
       }
 
       const { object } = activity;
       const [type, id] = object.split(':');
-  
-      activity.actor = getUserById(activity.actor, context);
-  
+
+      activity.actor = await getUserById(activity.actor, context);
+
       switch (type) {
         case 'comment':
-          activity.object = comment(null, { id }, context);
+          activity.object = await comment(null, { id }, context);
           break;
         case 'article':
-          activity.object = article(null, { id }, context);
+          activity.object = await article(null, { id }, context);
           break
         case 'follow':
         case 'subscription':
-          activity.object = getUserById(id, context);
+          activity.object = await getUserById(id, context);
           break;
         default:
           activity.object = null;
@@ -59,15 +68,57 @@ const feed = async (
     }
 
     // Filter out any off the user's activities (which got nulled)
-    feed.results[i].activities = feed.results[i].activities.filter(Boolean);
+    if (feed?.results[i]?.activities) {
+      feed.results[i].activities = feed.results[i].activities.filter(Boolean);
+    }
   }
 
+  // Filter out any results that got nulled
+  feed.results = feed.results.filter(Boolean);
+
   return feed as Feed;
+}
+
+const profileFeed = async (
+  _: null,
+  args: { userId: string },
+  context: Context,
+): Promise<ProfileFeed> => {
+  const timeline = context.stream.feed('user', args.userId);
+  const feed = await timeline.get({ limit: 20 }) as any;
+
+  // Loop through results and resolve them
+  for (let i = 0; i < feed.results.length; i++) {
+    const result = feed.results[i];
+
+    const { object } = result;
+    const [type, id] = object.split(':');
+
+    result.actor = await getUserById(result.actor, context);
+
+    switch (type) {
+      case 'comment':
+        result.object = await comment(null, { id }, context);
+        break;
+      case 'article':
+        result.object = await article(null, { id }, context);
+        break
+      case 'follow':
+      case 'subscription':
+        result.object = await getUserById(id, context);
+        break;
+      default:
+        result.object = null;
+    }
+  }
+  
+  return feed as ProfileFeed;
 }
 
 export default {
   Query: {
     feed,
+    profileFeed,
   },
   FeedActivityObject: {
     __resolveType(obj: any): string | null {

--- a/src/resolvers/follows.ts
+++ b/src/resolvers/follows.ts
@@ -48,6 +48,7 @@ export const followUser = async (
     verb: 'followed',
     objectType: 'follow',
     objectId: userToFollow.id,
+    to: [`user:${userToFollow.id}`],
   });
 
   return { userId: userToFollow.id };

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -5,6 +5,7 @@ type Query {
   articlesByUser(userId: ID!, drafts: Boolean): [Article]
   commentsByResourceId(resourceId: ID!): [Comment]
   feed: Feed
+  profileFeed(userId: ID): ProfileFeed
   stripeSession(id: ID!, stripeUserId: ID!): StripeSession!
   subscription(id: ID!): Subscription!
   user(username: String!): User
@@ -164,6 +165,11 @@ type FeedActivity {
   verb: String!
   time: String!
   object: FeedActivityObject
+}
+
+type ProfileFeed {
+  next: String!
+  results: [FeedActivity]!
 }
 
 enum Category {


### PR DESCRIPTION
This PR:
- [x] Adds `profileFeed` query
- [x] Fixes a bug in the `feed` where if a user was the only actor, it wouldn't filter out properly
- [x] Adds follow events onto the timeline of a user being followed (will show `X followed you` on their profile)