### PR TITLE
Remove activity when a user deletes an article

### DIFF
--- a/src/lib/stream.ts
+++ b/src/lib/stream.ts
@@ -86,15 +86,35 @@ export const addActivity = ({
     time: new Date().toISOString(),
   };
 
-  if (verb === 'article') {
-    activity.to = [...activity.to, `${objectType}:${objectId}`];
-  }
-
   try {
     const currUserFeed = context.stream.feed('user', context.userId);
     currUserFeed.addActivity(activity);
   } catch (error) {
     console.error(`Failed to add activity ${verb} feed:`, error?.detail || error, activity);
+  }
+}
+
+export const removeActivity = ({
+  context,
+  verb,
+  objectId,
+}: {
+  context: Context;
+  verb: string;
+  objectId: string;
+}): void => {
+  if (!context.userId) {
+    console.error(`Failed to add activity ${verb}, user context not found`);
+    return;
+  }
+
+  const foreignId = `${verb}:${objectId}`;
+
+  try {
+    const currUserFeed = context.stream.feed('user', context.userId);
+    currUserFeed.removeActivity({ foreignId });
+  } catch (error) {
+    console.error(`Failed to add activity ${verb} feed:`, error?.detail || error, foreignId);
   }
 }
 


### PR DESCRIPTION
This PR:
- [x] Deletes `published` activities from Stream when a user deletes an article (so it no longer shows up in the feeds)
- [x] Doesn't create a new Stream activity when an author edits and re-publishes an article (resolves [#87](https://github.com/getbard/webapp/issues/87))

_Note: Comments on a specific article stay in the feed even if the article is deleted..._