### PR TITLE
Make the line break eliminator not a piece of shit

### DIFF
--- a/src/lib/slate.ts
+++ b/src/lib/slate.ts
@@ -48,14 +48,18 @@ export const serializeHtml = (node: Node): string => {
   }
 }
 
-const nodeIsEmpty = (node: Node): boolean => {
-  return !node?.children?.length || (node?.children?.length === 1 && Text.isText(node.children[0]) && node.children[0].text === '');
+const isEmptyParagraph = (node: Node): boolean => {
+  if (node.type !== 'paragraph') {
+    return false;
+  }
+
+  return node?.children.length === 1 && !node?.children[0]?.text.trim();
 }
 
 // We want to eliminate consecutive line breaks from our contet
 export const lineBreakEliminator = (nodes: Node[]): Node[] => {
-  if (!nodes) {
-    return [];
+  if (Text.isText(nodes)) {
+    return nodes;
   }
 
   const nodesToRemove: number[] = [];
@@ -68,9 +72,11 @@ export const lineBreakEliminator = (nodes: Node[]): Node[] => {
       continue;
     }
 
-    currNode.children = lineBreakEliminator(currNode.children);
+    if (currNode.children) {
+      currNode.children = lineBreakEliminator(currNode.children);
+    }
 
-    if (nodeIsEmpty(prevNode) && nodeIsEmpty(currNode)) {
+    if (isEmptyParagraph(prevNode) && isEmptyParagraph(currNode)) {
       nodesToRemove.push(i);
     }
   }

--- a/src/resolvers/articles.ts
+++ b/src/resolvers/articles.ts
@@ -380,8 +380,7 @@ const publishArticle = async (
   // The article has content because it is checked above
   // Eliminate all consecutive line breaks so we don't have
   // crappy looking content
-  // TODO: Fix this so it isn't broke
-  // updatedArticle.content = JSON.stringify(lineBreakEliminator(JSON.parse(updatedArticle.content!)));
+  updatedArticle.content = JSON.stringify(lineBreakEliminator(JSON.parse(updatedArticle.content!)));
 
   await context.db
     .doc(`articles/${article.id}`)

--- a/src/resolvers/comments.ts
+++ b/src/resolvers/comments.ts
@@ -123,8 +123,7 @@ const updateComment = async (
     throw new UserInputError('Comment must have message');
   }
 
-  // TODO: Fix this so it aint broke
-  // updatedComment.message = JSON.stringify(lineBreakEliminator(JSON.parse(updatedComment.message!)));
+  updatedComment.message = JSON.stringify(lineBreakEliminator(JSON.parse(updatedComment.message!)));
 
   await context.db.doc(`comments/${updatedComment.id}`).set(updatedComment, { merge: true });
 


### PR DESCRIPTION
This PR makes the line break eliminator a bit easy to parse and stops it from deleting content after links.

Resolves [#144](https://github.com/getbard/webapp/issues/144).