### PR TITLE
Enable updating Stripe plans

### DIFF
--- a/src/resolvers/users.ts
+++ b/src/resolvers/users.ts
@@ -281,6 +281,31 @@ const profileSections = async (
     } as ProfileSection));
 }
 
+const stripeDashboardUrl = async (
+  parent: User,
+  _: null,
+  context: Context,
+): Promise<string | null> => {
+  if (!parent?.stripeUserId) {
+    return null;
+  }
+
+  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
+    apiVersion: '2020-03-02',
+    typescript: true,
+  });
+
+  try {
+    const loginLink: Stripe.LoginLink = await stripe.accounts.createLoginLink(parent.stripeUserId);
+    return loginLink?.url;
+  } catch (error) {
+    console.error('Failed to fetch Stripe Dashboard URL:', error);
+    Sentry.captureException(error);
+  }
+
+  return null;
+}
+
 export default {
   Query: {
     user,
@@ -296,5 +321,6 @@ export default {
     followers,
     following,
     profileSections,
+    stripeDashboardUrl,
   }
 }

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -26,6 +26,7 @@ type Mutation {
   createStripeSession(input: CreateStripeSessionInput!): CreateStripeSessionPayload!
   createSubscription(input: CreateSubscriptionInput!): CreateSubscriptionPayload!
   cancelSubscription(input: CancelSubscriptionInput!): CancelSubscriptionPayload!
+  updateStripePlanPrice(input: UpdateStripePlanPriceInput!): UpdateStripePlanPricePayload!
   followUser(input: FollowUserInput!): FollowUserPayload!
   unfollowUser(input: UnfollowUserInput!): UnfollowUserPayload!
   createComment(input: CreateCommentInput!): CreateCommentPayload!
@@ -102,6 +103,7 @@ type User {
   stripeUserId: String
   stripePlanId: String
   stripePlan: StripePlan
+  stripeDashboardUrl: String
   profileSections: [ProfileSection]
 }
 
@@ -429,4 +431,12 @@ input DeleteProfileSectionInput {
 type DeleteProfileSectionPayload {
   id: ID!
   deletedAt: String!
+}
+
+input UpdateStripePlanPriceInput {
+  amount: Int!
+}
+
+type UpdateStripePlanPricePayload {
+  id: ID!
 }


### PR DESCRIPTION
This PR allows a user to update their Stripe plan price. It creates a _new_ plan and deletes the old one (which has no affect on people subscribed to that old plan).