### PR TITLE
Handle edge case for files with () in them

### DIFF
--- a/src/resolvers/images.ts
+++ b/src/resolvers/images.ts
@@ -28,8 +28,8 @@ const uploadImage = async (
   const storeageClient = storage();
   const bucket = storeageClient.bucket(process.env.IMAGE_BUCKET_NAME);
 
-  // Replaces () in case someone uploads a file with (1)
-  const fileName = `${cuid()}-${input.name.replace(/ *\([^)]*\) */g, '')}`;
+  // Append time for super uniqueness
+  const fileName = `${cuid()}-${new Date().getTime()}`;
   const file = bucket.file(fileName);
 
   const base64EncodedImageString = input.content.replace(/^data:image\/\w+;base64,/, '');


### PR DESCRIPTION
This PR resolves a bug that happened if people uploaded a file with `()` in them. This is pretty common to see when there is a duplicate file on your computer for example. Instead of keeping the user's original filename, we just create a `cuid` and throw the time on it.